### PR TITLE
[patch] calendar_valid

### DIFF
--- a/ghdecoy.py
+++ b/ghdecoy.py
@@ -208,9 +208,11 @@ def get_calendar(user):
 def calendar_valid(cal):
     """Quick santiy check to see if the fetched calendar looks valid."""
 
+    print(type(cal))
+    svg = 'js-calendar-graph-svg'
     if len(cal) < 495:
         return False
-    if cal[0].startswith('<svg ') or cal[1].startswith('<svg '):
+    if any(svg in c for c in cal):
         return True
     return False
 

--- a/ghdecoy.py
+++ b/ghdecoy.py
@@ -208,7 +208,6 @@ def get_calendar(user):
 def calendar_valid(cal):
     """Quick santiy check to see if the fetched calendar looks valid."""
 
-    print(type(cal))
     svg = 'js-calendar-graph-svg'
     if len(cal) < 495:
         return False


### PR DESCRIPTION
It seems that the page containing the SVG calendar changed again, changed ``calendar_valid`` to look for the graph SVG class in the whole list instead of the SVG tag in first two positions.